### PR TITLE
Nix build fixes:`nix build` currently fails on macOS with nix 2.2.1 and ghc-8.6.3

### DIFF
--- a/src/Asm.hs
+++ b/src/Asm.hs
@@ -22,7 +22,7 @@ import Control.Monad.State
 import Data.ByteString.Short (ShortByteString, unpack)
 import qualified Data.ByteString.Short as SBS
 import Data.Map.Strict (Map, restrictKeys)
-import Data.Semigroup
+import Data.Semigroup ()
 #endif
 import Data.Bits
 import Data.Char

--- a/src/Boost.hs
+++ b/src/Boost.hs
@@ -10,7 +10,7 @@ module Boost
   ) where
 
 #ifndef __HASTE__
-import Data.Semigroup
+import Data.Semigroup ()
 #endif
 
 import Ast

--- a/src/DHC.hs
+++ b/src/DHC.hs
@@ -231,7 +231,7 @@ gather cl globs env (Ast ast) = case ast of
       (t1, qs1) <- instantiate qt
       pure $ foldl' ((AAst t1 .) . (:@)) (AAst t1 $ Var v) $ (\(a, b) -> AAst (TC $ "Dict-" ++ a) $ Placeholder a (TV b)) <$> qs1
     | Just (ty, _, typeClass) <- M.lookup v $ methods cl -> do
-      (t1, [(_, x)]) <- instantiate (ty, [typeClass])
+      ~(t1, [(_, x)]) <- instantiate (ty, [typeClass])
       pure $ AAst t1 $ Placeholder v $ TV x
     | Just (ma, gt) <- M.lookup v globs ->
       flip AAst (maybe (Var v) (uncurry Pack) ma) . fst <$> instantiate (gt, [])

--- a/src/Hero/Parse.hs
+++ b/src/Hero/Parse.hs
@@ -240,7 +240,7 @@ wasm = do
       es <- rep varuint32 $ do
         index <- varuint32
         when (index /= 0) $ bad "MVP allows at most one table"
-        [I32_const offset] <- codeBlock w
+        ~[I32_const offset] <- codeBlock w
         ns <- rep varuint32 $ do
           i <- varuint32
           when (i > functionCount w) $ bad "function index out of range"
@@ -355,7 +355,7 @@ wasm = do
             pure $ Call i
           0x11 -> do
             i <- varuint32
-            0 <- varuint1
+            ~ 0 <- varuint1
             when (i >= length (types w)) $ bad "Call_indirect index out of range"
             pure $ Call_indirect $ types w !! i
           _ -> bad ("bad opcode " ++ show opcode)


### PR DESCRIPTION
- Hard failure due to MFP[1] errors
- Minor fix for an 'unused-imports' warning

[1] https://wiki.haskell.org/MonadFail_Proposal

Relevant version info from nix logs:

Using Cabal-2.4.0.1 compiled by ghc-8.6
Using compiler: ghc-8.6.3